### PR TITLE
feat: add forwardRef to RecipesModule in RedisModule to resolve circu…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/mongoose": "^11.0.3",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^10.0.0",
+        "@nestjs/schedule": "^6.0.0",
         "@nestjs/swagger": "^7.4.2",
         "bcrypt": "^6.0.0",
         "class-validator": "^0.14.2",
@@ -1935,6 +1936,19 @@
         "@nestjs/core": "^10.0.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-6.0.0.tgz",
+      "integrity": "sha512-aQySMw6tw2nhitELXd3EiRacQRgzUKD9mFcUZVOJ7jPLqIBvXOyvRWLsK9SdurGA+jjziAlMef7iB5ZEFFoQpw==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "4.3.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "10.2.3",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-10.2.3.tgz",
@@ -2416,6 +2430,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.6.2.tgz",
+      "integrity": "sha512-R/BdP7OxEMc44l2Ex5lSXHoIXTB2JLNa3y2QISIbr58U/YcsffyQrYW//hZSdrfxrjRZj3GcUoxMPGdO8gSYuw==",
+      "license": "MIT"
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -4130,6 +4150,19 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cron": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.3.0.tgz",
+      "integrity": "sha512-ciiYNLfSlF9MrDqnbMdRWFiA6oizSF7kA1osPP9lRzNu0Uu+AWog1UKy7SkckiDY2irrNjeO6qLyKnXC8oxmrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.6.0",
+        "luxon": "~3.6.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -7216,6 +7249,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@nestjs/mongoose": "^11.0.3",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/schedule": "^6.0.0",
     "@nestjs/swagger": "^7.4.2",
     "bcrypt": "^6.0.0",
     "class-validator": "^0.14.2",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -7,6 +7,8 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { RecipesModule } from 'src/recipes/recipes.module';
 import { RedisModule } from 'src/redis/redis.module';
+import { ScheduleModule } from '@nestjs/schedule';
+import { RedisSyncService } from 'src/redis/redis-sync.service';
 
 @Module({
   imports: [
@@ -16,8 +18,9 @@ import { RedisModule } from 'src/redis/redis.module';
     AuthModule,
     RecipesModule,
     RedisModule,
+    ScheduleModule.forRoot(),
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [AppService, RedisSyncService],
 })
 export class AppModule {}

--- a/src/recipes/recipes.module.ts
+++ b/src/recipes/recipes.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 import { RecipesService } from './recipes.service';
 import { RecipesController } from './recipes.controller';
@@ -7,10 +7,12 @@ import { RedisModule } from 'src/redis/redis.module';
 
 @Module({
   imports: [
-    RedisModule,
+    forwardRef(() => RedisModule),
+    MongooseModule.forFeature([{ name: Recipe.name, schema: RecipeSchema }]),
     MongooseModule.forFeature([{ name: Recipe.name, schema: RecipeSchema }]),
   ],
   controllers: [RecipesController],
   providers: [RecipesService],
+  exports: [MongooseModule],
 })
 export class RecipesModule {}

--- a/src/redis/redis-sync.service.ts
+++ b/src/redis/redis-sync.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { RedisService } from './redis.service';
+import { InjectModel } from '@nestjs/mongoose';
+import { Recipe, RecipeDocument } from 'src/recipes/schemas/recipe.schema';
+import { Model } from 'mongoose';
+import { Cron, CronExpression } from '@nestjs/schedule';
+
+@Injectable()
+export class RedisSyncService {
+  private readonly logger = new Logger(RedisSyncService.name);
+
+  constructor(
+    private readonly redisService: RedisService,
+    @InjectModel(Recipe.name) private recipeModel: Model<RecipeDocument>,
+  ) {}
+
+  @Cron(CronExpression.EVERY_5_MINUTES)
+  async syncRedisToMongo() {
+    this.logger.log('Synchronizing data from Redis to MongoDB...');
+    const recipes = await this.recipeModel.find({}, '_id').lean();
+
+    for (const recipe of recipes) {
+      const views = await this.redisService.getRecipeViews(
+        recipe._id.toString(),
+      );
+
+      const likes = await this.redisService.getLikesCount(
+        recipe._id.toString(),
+      );
+
+      await this.recipeModel.updateOne(
+        { _id: recipe._id },
+        { $set: { views, likes } },
+      );
+    }
+    this.logger.log('Synchronization completed');
+  }
+}

--- a/src/redis/redis.module.ts
+++ b/src/redis/redis.module.ts
@@ -1,14 +1,18 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { RedisService } from './redis.service';
+import { RedisSyncService } from './redis-sync.service';
 import Redis from 'ioredis';
+import { RecipesModule } from 'src/recipes/recipes.module';
 
 @Module({
+  imports: [forwardRef(() => RecipesModule)],
   providers: [
     {
       provide: 'Redis',
       useFactory: () => new Redis(process.env.REDIS_URL),
     },
     RedisService,
+    RedisSyncService,
   ],
   exports: ['Redis', RedisService],
 })


### PR DESCRIPTION
This commit updates RedisModule to import RecipesModule using forwardRef, resolving circular dependency issues. It ensures that the Recipe Mongoose model can be injected into RedisSyncService, enabling scheduled synchronization of Redis data (likes and views) to MongoDB.